### PR TITLE
Create models landing page

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -15,6 +15,7 @@ website:
     - href: index.qmd
       text: Accueil
     - text: Modèles
+      href: templates/index.qmd
       menu:
         - href: templates/quarto.qmd
           text: Gabarits Quarto

--- a/index.qmd
+++ b/index.qmd
@@ -15,7 +15,7 @@ site:
     left:
       - href: index.qmd
         text: Accueil
-      - href: templates/quarto.qmd
+      - href: templates/index.qmd
         text: Modèles
       - href: outils.qmd
         text: Outils
@@ -58,7 +58,7 @@ Ce site rassemble divers matériels pédagogiques, modèles Quarto, gabarits Git
 
 ## 🚀 Démarrage rapide
 
-1. Explorez les modèles disponibles dans la section [Modèles](templates/quarto.qmd).
+1. Explorez les modèles disponibles dans la section [Modèles](templates/index.qmd).
 2. Consultez les outils proposés dans [Outils](outils.qmd).
 3. Apprenez avec nos [Tutoriels](tutoriels.qmd).
 

--- a/templates/_quarto.yml
+++ b/templates/_quarto.yml
@@ -2,6 +2,8 @@ website:
   sidebar:
     style: "floating"
     contents:
+      - href: index.qmd
+        text: "Accueil des modèles"
       - href: quarto.qmd
         text: "Modèles Quarto"
       - href: site-web.qmd

--- a/templates/index.qmd
+++ b/templates/index.qmd
@@ -1,0 +1,29 @@
+---
+title: "Accueil des modèles"
+format:
+  html:
+    toc: true
+    toc-title: "Contenu de la page"
+    embed-resources: true
+    link-external-newwindow: true
+    code-link: true
+---
+
+# 🧰 Nos modèles disponibles
+
+Cette section du site regroupe plusieurs gabarits prêts à l'emploi. Utilisez le menu déroulant **Modèles** en haut de la page pour accéder rapidement aux différentes catégories.
+
+- [Gabarits Quarto](quarto.qmd) : présentations, rapports, devoirs ou examens.
+- [Site web Quarto](site-web.qmd) : structure de base pour créer votre propre site.
+
+## 📥 Comment dupliquer un modèle
+
+1. Dans RStudio, ouvrez l'onglet **Terminal** (et non la console R).
+2. Exécutez la commande correspondant au modèle souhaité :
+   ```bash
+   quarto use template <utilisateur>/<repo>/<modele>
+   ```
+3. Un nouveau dossier est créé avec tous les fichiers nécessaires (\*.qmd, css, images…).
+4. Ouvrez ce dossier comme projet et personnalisez les fichiers selon vos besoins.
+
+Ainsi, chaque modèle peut être cloné localement en quelques secondes puis adapté à vos cours.


### PR DESCRIPTION
## Summary
- add a new landing page for the Models section
- update navbar links to point to this page
- adjust quick start link on home page
- list new page in the templates sidebar

## Testing
- `quarto --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436fa7bab883229c7ed601efe00c8c