### PR TITLE
ci: setup GitHub Pages deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,71 @@
+name: Build and Deploy Quarto to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      # --- Python (pour les chunks Python/reticulate) ---
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install Python dependencies (if any)
+        run: |
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; else echo "No requirements.txt"; fi
+
+      # --- R (pour les chunks R) ---
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+      - name: Setup renv
+        uses: r-lib/actions/setup-renv@v2
+        with:
+          cache-version: 1
+      # Si tu n'utilises pas renv, remplace l'étape ci-dessus par une installation des packages nécessaires.
+
+      - name: Render Quarto project
+        env:
+          # Optionnel : indique à reticulate d'utiliser le Python de l'action
+          RETICULATE_PYTHON: ${{ env.pythonLocation }}/bin/python
+        run: |
+          quarto check install
+          quarto render
+        # ⚠️ Si ton `_quarto.yml` utilise un `output-dir` différent, adapte l'étape "Upload Pages artifact".
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,9 @@
 .Ruserdata
 *.Rproj
 
-
 /.quarto/
 _site/
+docs/
 
 # macOS files
 .DS_Store


### PR DESCRIPTION
## Summary
- build and deploy Quarto site to GitHub Pages with Pages workflow
- ignore built `docs/` and `_site/` directories

## Testing
- `quarto --version` *(fails: command not found)*

**Reminder:** In repository settings, set **Pages → Build and deployment → Source = GitHub Actions**.

------
https://chatgpt.com/codex/tasks/task_e_689b4de188e483229c6715e6a7fa1901